### PR TITLE
Fix "Elements must have their visible text as part of their accessible name" accessibility issue found with Lighthouse.

### DIFF
--- a/src/Layout/Blogpost.elm
+++ b/src/Layout/Blogpost.elm
@@ -272,7 +272,7 @@ viewListItem metadata =
                     [ Route.Blog__Slug_ { slug = metadata.slug }
                         |> Route.link
                             [ Attrs.class "text-primary-700 dark:text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                            , Attrs.attribute "aria-label" ("Read \"" ++ metadata.title ++ "\"")
+                            , Attrs.attribute "aria-label" ("Read more about \"" ++ metadata.title ++ "\"")
                             ]
                             [ Html.text "Read more →" ]
                     ]


### PR DESCRIPTION
### Problem

Lighthouse's accessibility check found that the `aria-label` for the "Read more" button is not following the acceptable naming conventions referencing this article [https://dequeuniversity.com/rules/axe/4.7/label-content-name-mismatch](https://dequeuniversity.com/rules/axe/4.7/label-content-name-mismatch). According to it all of the visible text must also be a part of the elements accessible name. It seems like the `→` symbol does not need to be accounted for.

### Solution

Change the `aria-label` to include all of the text in the visible element.
This solution bumps the Lighthouse accessibility score from 95 to a 100.
