### PR TITLE
remove leading '/' from relative file path

### DIFF
--- a/src/Content/About.elm
+++ b/src/Content/About.elm
@@ -63,4 +63,4 @@ authorDecoder slug body =
 
 defaultAuthor : BackendTask { fatal : FatalError, recoverable : File.FileReadError Decode.Error } Author
 defaultAuthor =
-    File.bodyWithFrontmatter (authorDecoder "default") "/content/authors/default.md"
+    File.bodyWithFrontmatter (authorDecoder "default") "content/authors/default.md"


### PR DESCRIPTION
### Problem
Relative file paths that start with a leading `/` does not work in elm-pages 10.0.3 (https://github.com/dillonkearns/elm-pages/blob/master/CHANGELOG-NPM.md#3010---2024-01-10)

### Solution
Remove leading `/` to be compatible with later versions of elm-pages.