### PR TITLE
Perform markdown parsing in build-time-only codepaths

### DIFF
--- a/src/Layout/About.elm
+++ b/src/Layout/About.elm
@@ -152,6 +152,6 @@ view author =
                 [ Attrs.class "prose max-w-none pb-8 pt-8 dark:prose-invert xl:col-span-2"
                 ]
               <|
-                Markdown.toHtml author.body
+                Markdown.toHtmlBlocks author.body
             ]
         ]

--- a/src/Layout/Blogpost.elm
+++ b/src/Layout/Blogpost.elm
@@ -155,7 +155,7 @@ viewBlogpost { metadata, body, previousPost, nextPost } =
             metadata.description
         , Html.article
             [ Attrs.class "mx-auto prose lg:prose-xl dark:prose-invert" ]
-            (Markdown.blogpostToHtml body)
+            (Markdown.blocksToHtml body)
         , Html.div
             [ Attrs.class "mt-8 border-t grid grid-cols-1 text-sm font-medium sm:grid-cols-2 sm:text-base" ]
             [ previous, next ]

--- a/src/Layout/Markdown.elm
+++ b/src/Layout/Markdown.elm
@@ -1,4 +1,4 @@
-module Layout.Markdown exposing (blogpostToHtml, toHtml)
+module Layout.Markdown exposing (blocksToHtml, toHtml)
 
 import Html exposing (Html)
 import Html.Attributes as Attrs
@@ -115,18 +115,10 @@ blogpostRenderer =
     }
 
 
-blogpostToHtml : String -> List (Html msg)
-blogpostToHtml markdownString =
-    markdownString
-        |> Markdown.Parser.parse
-        |> Result.mapError (\_ -> "Markdown error.")
-        |> Result.andThen
-            (\blocks ->
-                Markdown.Renderer.render
-                    blogpostRenderer
-                    blocks
-            )
-        |> Result.withDefault [ Html.text "failed to read markdown" ]
+blocksToHtml : List Block.Block -> List (Html msg)
+blocksToHtml blocks =
+    Markdown.Renderer.render blogpostRenderer blocks
+        |> Result.withDefault [ Html.text "failed to render markdown" ]
 
 
 toHtml : String -> List (Html msg)

--- a/src/Layout/Markdown.elm
+++ b/src/Layout/Markdown.elm
@@ -1,9 +1,8 @@
-module Layout.Markdown exposing (blocksToHtml, toHtml)
+module Layout.Markdown exposing (blocksToHtml, toHtmlBlocks)
 
 import Html exposing (Html)
 import Html.Attributes as Attrs
 import Markdown.Block as Block
-import Markdown.Parser
 import Markdown.Renderer exposing (defaultHtmlRenderer)
 import Parser exposing (DeadEnd)
 import Phosphor
@@ -121,15 +120,7 @@ blocksToHtml blocks =
         |> Result.withDefault [ Html.text "failed to render markdown" ]
 
 
-toHtml : String -> List (Html msg)
-toHtml markdownString =
-    markdownString
-        |> Markdown.Parser.parse
-        |> Result.mapError (\_ -> "Markdown error.")
-        |> Result.andThen
-            (\blocks ->
-                Markdown.Renderer.render
-                    renderer
-                    blocks
-            )
-        |> Result.withDefault [ Html.text "failed to read markdown" ]
+toHtmlBlocks : List Block.Block -> List (Html msg)
+toHtmlBlocks blocks =
+    Markdown.Renderer.render renderer blocks
+        |> Result.withDefault [ Html.text "failed to render markdown" ]


### PR DESCRIPTION
Hey! I noticed on @jfmengels' blog, which is based on this template, that there was an optimization opportunity. `elm-pages` optimizes the frontend bundle by stripping out (dead code eliminating) any code in your `data`, `action`, or `pages` functions. That means that if you have a package or part of a package that has a big bundle size contribution, you can remove it by only calling that code in the codepath from those functions and it will auto-magically be stripped out from your frontend bundle!

In addition to the bundle size consideration, you can avoid doing expensive JS workloads by doing them at build-time. Whatever the result of your `data` function is for example will be exactly the data that is "frozen in time" and picked up when the JS code hydrates - no computation needed.

Parsing (including markdown parsing) is very expensive in both regards, bundle size and computation.

NOTE: One caveat, I actually had to [push along a fix to elm-pages](https://github.com/dillonkearns/elm-pages/pull/544) that applies this optimization to the preRender `pages` functions as well, so this will only take effect once you also merge a follow-up PR I am going to make! You'll need elm-pages 3.0.27 to take advantage of this. I figured I'd make it a separate PR because there are several outdated deps so it will become a more substantial PR.

It turns out that this change alone takes the `elm.js` bundle size down from 246K down to 185K! ✨

I hope the code changes look alright to you. Let me know if there is anything you want to discuss. Cheers and thanks for the project!