### PR TITLE
Make inline code spans look better

### DIFF
--- a/src/Layout/Markdown.elm
+++ b/src/Layout/Markdown.elm
@@ -108,6 +108,9 @@ blogpostRenderer =
                             |> Phosphor.toHtml [ SvgAttrs.class "text-primary-300 inline-block text-xl ml-2" ]
                         ]
                     ]
+        , codeSpan =
+            \context ->
+                Html.code [ Attrs.class "not-prose" ] [ Html.text context ]
         , codeBlock =
             \block ->
                 syntaxHighlight block

--- a/style.css
+++ b/style.css
@@ -50,6 +50,12 @@ code.elmsh {
   padding: 0;
 }
 
+code.not-prose {
+  border-radius: .3em;
+  background: rgba(255,229,100,.2);
+  padding: .15em .2em .05em;
+}
+
 .elmsh-line:before {
   content: attr(data-elmsh-lc);
   display: inline-block;


### PR DESCRIPTION
This is what I used for https://jfmengels.net/. Feel free to take or ignore.

Before:

<img width="613" height="112" alt="image" src="https://github.com/user-attachments/assets/ce34455d-084e-458a-bc37-469239f1a98e" />

After:

<img width="613" height="112" alt="Screenshot from 2026-02-12 16-27-57" src="https://github.com/user-attachments/assets/8408598d-82f8-4035-b0f9-a03e70f38a4e" />
