### PR TITLE
Add basic RSS feed with no content body.

### DIFF
--- a/app/Api.elm
+++ b/app/Api.elm
@@ -2,10 +2,13 @@ module Api exposing (manifest, routes)
 
 import ApiRoute exposing (ApiRoute)
 import BackendTask exposing (BackendTask)
+import Content.Blogpost
 import FatalError exposing (FatalError)
 import Html exposing (Html)
+import Pages
 import Pages.Manifest as Manifest
 import Route exposing (Route)
+import Rss
 import Settings
 
 
@@ -14,7 +17,44 @@ routes :
     -> (Maybe { indent : Int, newLines : Bool } -> Html Never -> String)
     -> List (ApiRoute ApiRoute.Response)
 routes getStaticRoutes htmlToString =
-    []
+    [ rssRoute ]
+
+
+rssRoute : ApiRoute ApiRoute.Response
+rssRoute =
+    ApiRoute.succeed
+        (Content.Blogpost.allBlogposts
+            |> BackendTask.map
+                (\blogposts ->
+                    Rss.generate
+                        { title = Settings.title
+                        , description = Settings.subtitle
+                        , url = Settings.canonicalUrl ++ "/blog"
+                        , lastBuildTime = Pages.builtAt
+                        , generator = Just "elm-pages"
+                        , items = List.map blogpostToRssItem blogposts
+                        , siteUrl = Settings.canonicalUrl
+                        }
+                )
+        )
+        |> ApiRoute.literal "blog"
+        |> ApiRoute.slash
+        |> ApiRoute.literal "feed.xml"
+        |> ApiRoute.single
+
+
+blogpostToRssItem : Content.Blogpost.Blogpost -> Rss.Item
+blogpostToRssItem { metadata } =
+    { title = metadata.title
+    , description = metadata.description |> Maybe.withDefault ""
+    , url = "/blog/" ++ metadata.slug
+    , categories = metadata.tags
+    , author = metadata.authors |> List.map .name |> String.join ", "
+    , pubDate = Rss.Date (Content.Blogpost.getPublishedDate metadata)
+    , content = Nothing
+    , contentEncoded = Nothing
+    , enclosure = Nothing
+    }
 
 
 manifest : Manifest.Config

--- a/app/Site.elm
+++ b/app/Site.elm
@@ -18,5 +18,6 @@ head : BackendTask FatalError (List Head.Tag)
 head =
     [ Head.metaName "viewport" (Head.raw "width=device-width,initial-scale=1")
     , Head.sitemapLink "/sitemap.xml"
+    , Head.rssLink "/blog/feed.xml"
     ]
         |> BackendTask.succeed

--- a/elm.json
+++ b/elm.json
@@ -28,6 +28,7 @@
             "justinmimbs/date": "4.1.0",
             "kuon/elm-string-normalize": "1.0.6",
             "pablohirafuji/elm-syntax-highlight": "3.7.1",
+            "dillonkearns/elm-rss": "2.0.5",
             "phosphor-icons/phosphor-elm": "2.1.0"
         },
         "indirect": {
@@ -58,6 +59,11 @@
             "stil4m/structured-writer": "1.0.3",
             "the-sett/elm-pretty-printer": "3.3.0",
             "the-sett/elm-syntax-dsl": "6.0.3",
+            "dillonkearns/elm-xml-encode": "1.0.1",
+            "dmy/elm-imf-date-time": "1.0.2",
+            "justinmimbs/time-extra": "1.2.0",
+            "lazamar/dict-parser": "1.0.2",
+            "ryan-haskell/date-format": "1.0.0",
             "wolfadex/elm-ansi": "3.0.1"
         }
     },

--- a/src/Content/Blogpost.elm
+++ b/src/Content/Blogpost.elm
@@ -6,6 +6,7 @@ module Content.Blogpost exposing
     , allBlogposts
     , allTags
     , blogpostFromSlug
+    , getPublishedDate
     )
 
 import Array


### PR DESCRIPTION
In the spirit of better to have something rather than nothing, here is an RSS feed that skips the body (just titles and publication date).

You could also add the rendered body, but this gets complicated because you don't have your CSS in the context of a feed reader, so you would likely want to render slightly differently.